### PR TITLE
ckb-next: get rid of pulseaudio dependency.

### DIFF
--- a/srcpkgs/ckb-next/template
+++ b/srcpkgs/ckb-next/template
@@ -1,23 +1,19 @@
 # Template file for 'ckb-next'
 pkgname=ckb-next
 version=0.4.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DDISABLE_UPDATER=1 -DUDEV_RULE_DIRECTORY=/usr/lib/udev/rules.d"
 hostmakedepends="qt5-devel pkg-config"
 makedepends="eudev-libudev-devel libdbusmenu-qt5-devel qt5-devel
  qt5-tools-devel qt5-x11extras-devel quazip-qt5-devel xcb-util-wm-devel
- $(vopt_if pulseaudio pulseaudio-devel)"
-depends="$(vopt_if pulseaudio pulseaudio)"
+ pulseaudio-devel"
 short_desc="Corsair RGB Driver for Linux"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ckb-next/ckb-next"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=6946bd035cdbbbd2f139e543d2ca84ba422176c62c3a3665b544118dc6d618d0
-build_options="pulseaudio"
-build_options_default="pulseaudio"
-desc_option_pulseaudio="Enable support for music visualizer animation"
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
As pipewire gets more common, it makes no sense to hard-depend on
pulseaudio anymore. Only leave pulseaudio-devel in makedepends, since
that's needed for pipewire anyway.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
